### PR TITLE
Do not automount serviceaccount and set namespace using downward API

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: mehdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: shard
         image: quay.io/mhausenblas/mehdb:0.6
@@ -22,6 +23,10 @@ spec:
         env:
         - name: MEHDB_DATADIR
           value: "/mehdbdata"
+        - name: MEHDB_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         livenessProbe:
           initialDelaySeconds: 2
           periodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -221,9 +221,8 @@ func status(w http.ResponseWriter, r *http.Request) {
 
 func currentns() string {
 	ns := "default"
-	if _, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-		currentns, _ := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-		ns = string(currentns)
+	if n := os.Getenv("MEHDB_NAMESPACE"); n != "" {
+		ns = n
 	}
 	return ns
 }


### PR DESCRIPTION
Your mehdb is an excellent StatefulSet example but I'd like to use it with `automountServiceAccountToken: false` and it currently looks for the Namespace value in the mounted serviceaccount directory.  

These small changes allow this by using the namespace from the MEHDB_NAMESPACE environment variable set using the downward API.

Signed-off-by: Keith Burdis <keith.burdis@gs.com>